### PR TITLE
Initial CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,57 @@
+name: PR
+
+on: [push, pull_request]
+env:
+  RUST_BACKTRACE: 1
+jobs:
+  checks:
+    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
+    name: run checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        id: toolchain
+        name: install rustfmt and clippy
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - name: cargo caching
+        uses: actions/cache@v2.1.4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+      - name: run cargo fmt
+        run: cargo fmt --all -- --check
+      - name: run clippy
+        run: cargo clippy --all-targets --all-features
+  unit-tests:
+    name: run unit tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: install rust
+        id: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: cargo caching
+        uses: actions/cache@v2.1.4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+      - name: run unit tests
+        run: cargo test --bin tdl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ regex = "~1.5"
 structopt = "~0.3"
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"
+
+[target.'cfg(unix)'.dependencies]
 skim = "~0.9.4"
 
 [dev-dependencies]

--- a/src/commands/profile.rs
+++ b/src/commands/profile.rs
@@ -56,7 +56,7 @@ pub fn run_profile_cmd(
             );
             let mut is_default = default;
             let mut settings = repository.get()?;
-            if settings.profiles.len() == 0 {
+            if settings.profiles.is_empty() {
                 // If there are no existing profiles, the first one *must* be set as the default,
                 // even if the user didn't specify that.
                 is_default = true;
@@ -80,7 +80,7 @@ pub fn run_profile_cmd(
                 ))
                 .suggestion("Use the 'source-port list' command to find a valid Source Port"));
             }
-            if settings.profiles.len() > 0 && default {
+            if !settings.profiles.is_empty() && default {
                 let mut current = settings.profiles.iter_mut().find(|x| x.default).unwrap();
                 current.default = false;
                 info!("The current default profile is '{}'", current.name);
@@ -145,9 +145,9 @@ mod tests {
             SourcePortType::PrBoom
         );
         assert_eq!(settings.profiles[0].source_port_version, "2.6");
-        assert_eq!(settings.profiles[0].fullscreen, true);
-        assert_eq!(settings.profiles[0].music, true);
-        assert_eq!(settings.profiles[0].default, true);
+        assert!(settings.profiles[0].fullscreen);
+        assert!(settings.profiles[0].music);
+        assert!(settings.profiles[0].default);
         matches!(settings.profiles[0].skill, Skill::UltraViolence);
     }
 
@@ -189,9 +189,9 @@ mod tests {
             SourcePortType::PrBoom
         );
         assert_eq!(settings.profiles[0].source_port_version, "2.6");
-        assert_eq!(settings.profiles[0].fullscreen, true);
-        assert_eq!(settings.profiles[0].music, true);
-        assert_eq!(settings.profiles[0].default, true);
+        assert!(settings.profiles[0].fullscreen);
+        assert!(settings.profiles[0].music);
+        assert!(settings.profiles[0].default);
         matches!(settings.profiles[0].skill, Skill::UltraViolence);
     }
 
@@ -241,8 +241,8 @@ mod tests {
             SourcePortType::PrBoom
         );
         assert_eq!(settings.profiles[1].source_port_version, "2.6");
-        assert_eq!(settings.profiles[1].fullscreen, true);
-        assert_eq!(settings.profiles[1].music, false);
+        assert!(settings.profiles[1].fullscreen);
+        assert!(!settings.profiles[1].music);
         matches!(settings.profiles[1].skill, Skill::UltraViolence);
     }
 
@@ -286,16 +286,16 @@ mod tests {
         let repo = FileSettingsRepository::new(settings_file.to_path_buf()).unwrap();
         let settings = repo.get().unwrap();
         assert_eq!(settings.profiles.len(), 2);
-        assert_eq!(settings.profiles[0].default, false);
+        assert!(!settings.profiles[0].default);
         assert_eq!(settings.profiles[1].name, "prboom-nomusic");
         matches!(
             settings.profiles[1].source_port_type,
             SourcePortType::PrBoom
         );
         assert_eq!(settings.profiles[1].source_port_version, "2.6");
-        assert_eq!(settings.profiles[1].fullscreen, true);
-        assert_eq!(settings.profiles[1].music, false);
-        assert_eq!(settings.profiles[1].default, true);
+        assert!(settings.profiles[1].fullscreen);
+        assert!(!settings.profiles[1].music);
+        assert!(settings.profiles[1].default);
         matches!(settings.profiles[1].skill, Skill::UltraViolence);
     }
 
@@ -331,7 +331,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err().to_string(),
-            format!("The Source Port 'PrBoom' with version '2.7' does not exist")
+            "The Source Port 'PrBoom' with version '2.7' does not exist".to_string()
         )
     }
 }

--- a/src/commands/source_port.rs
+++ b/src/commands/source_port.rs
@@ -164,7 +164,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err().to_string(),
-            format!("There is already a PrBoom Source Port at version 2.6")
+            "There is already a PrBoom Source Port at version 2.6".to_string()
         )
     }
 

--- a/src/commands/wad.rs
+++ b/src/commands/wad.rs
@@ -21,7 +21,7 @@ pub enum WadCommand {
 
 pub fn run_wad_cmd(cmd: WadCommand) -> Result<(), Report> {
     match cmd {
-        WadCommand::LsDir { name, path } => {
+        WadCommand::LsDir { name: _, path } => {
             if let Some(path) = path {
                 let wad = WadMetadata::from_path(path)?;
                 debug!(

--- a/src/fake_source_port.rs
+++ b/src/fake_source_port.rs
@@ -20,21 +20,20 @@ fn main() -> Result<(), Report> {
     let mut prev = "".to_string();
     for arg in std::env::args().skip(1) {
         if prev == "-warp" {
-            println!("in here");
+            // The warp argument is an annoying special case, where it sometimes requires 2 values.
+            // TODO: this actually needs to be fixed to look up the iwad.
             warp_arg.push_str(&format!("{} ", arg.to_owned()));
             if warp_arg.len() >= 3 {
                 game_args.insert(prev.to_owned(), warp_arg.to_owned().trim().to_string());
             }
-        } else {
-            if arg.starts_with("-") {
-                if flags.iter().any(|x| **x == arg) {
-                    game_args.insert(arg.to_owned(), "true".to_string());
-                } else {
-                    prev = arg.to_owned();
-                }
+        } else if arg.starts_with('-') {
+            if flags.iter().any(|x| **x == arg) {
+                game_args.insert(arg.to_owned(), "true".to_string());
             } else {
-                game_args.insert(prev.to_owned(), arg.to_owned());
+                prev = arg.to_owned();
             }
+        } else {
+            game_args.insert(prev.to_owned(), arg.to_owned());
         }
     }
     for (arg, value) in game_args.iter() {

--- a/src/find.rs
+++ b/src/find.rs
@@ -8,7 +8,7 @@ use std::io::Cursor;
 use std::path::Path;
 
 #[cfg(target_family = "unix")]
-pub fn select_map_to_play<'a>() -> Result<(String, String), Report> {
+pub fn select_map_to_play() -> Result<(String, String), Report> {
     let mut wads_path = get_app_settings_dir_path()?;
     wads_path.push("wads");
 
@@ -40,12 +40,11 @@ pub fn select_map_to_play<'a>() -> Result<(String, String), Report> {
         .map(|out| out.selected_items)
         .unwrap();
     let split: Vec<String> = selected
-        .iter()
-        .nth(0)
+        .get(0)
         .unwrap()
         .output()
-        .split(" ")
-        .map(|s| String::from(s))
+        .split(' ')
+        .map(String::from)
         .collect();
     let selected_wad = Path::new(&split[0].clone())
         .file_stem()
@@ -53,7 +52,7 @@ pub fn select_map_to_play<'a>() -> Result<(String, String), Report> {
         .to_str()
         .unwrap()
         .to_owned();
-    Ok((String::from(selected_wad), split[1].clone()))
+    Ok((selected_wad, split[1].clone()))
 }
 
 #[cfg(target_family = "windows")]

--- a/src/find.rs
+++ b/src/find.rs
@@ -2,10 +2,12 @@ use crate::settings::get_app_settings_dir_path;
 use crate::storage::ObjectRepository;
 use crate::wad::WadEntry;
 use color_eyre::{Report, Result};
+#[cfg(target_family = "unix")]
 use skim::prelude::*;
 use std::io::Cursor;
 use std::path::Path;
 
+#[cfg(target_family = "unix")]
 pub fn select_map_to_play<'a>() -> Result<(String, String), Report> {
     let mut wads_path = get_app_settings_dir_path()?;
     wads_path.push("wads");
@@ -52,4 +54,9 @@ pub fn select_map_to_play<'a>() -> Result<(String, String), Report> {
         .unwrap()
         .to_owned();
     Ok((String::from(selected_wad), split[1].clone()))
+}
+
+#[cfg(target_family = "windows")]
+pub fn select_map_to_play<'a>() -> Result<(String, String), Report> {
+    unimplemented!();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,22 +44,19 @@ fn main() -> Result<(), Report> {
             map,
             profile,
         }) => {
-            let wad_to_play: String;
-            let map_to_play: Option<String>;
-            if megawad.is_none() {
+            if let Some(wad_to_play) = megawad {
+                run_play_cmd(wad_to_play, map, profile, repository)
+            } else {
                 let selected = select_map_to_play()?;
-                wad_to_play = selected.0;
-                map_to_play = Some(selected.1.to_owned());
+                let wad_to_play = selected.0;
+                let map_to_play = Some(selected.1);
                 info!(
                     "Selected {}: {}",
                     &wad_to_play,
                     map_to_play.as_ref().unwrap()
                 );
-            } else {
-                wad_to_play = megawad.unwrap();
-                map_to_play = map;
+                run_play_cmd(wad_to_play, map_to_play, profile, repository)
             }
-            run_play_cmd(wad_to_play, map_to_play, profile, repository)
         }
         Some(Command::Profile { cmd }) => run_profile_cmd(cmd, repository),
         Some(Command::SourcePort { cmd }) => run_source_port_cmd(cmd, &repository),

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -63,9 +63,9 @@ mod tests {
         matches!(profile.source_port_type, SourcePortType::PrBoom);
         assert_eq!(profile.source_port_version, "2.6um".to_string());
         matches!(profile.skill, Skill::UltraViolence);
-        assert_eq!(profile.fullscreen, true);
-        assert_eq!(profile.music, false);
-        assert_eq!(profile.default, true);
+        assert!(profile.fullscreen);
+        assert!(!profile.music);
+        assert!(profile.default);
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -230,20 +230,14 @@ mod user_settings {
     #[test]
     fn set_from_doom_home_should_set_fields_correctly() {
         let doom_home = assert_fs::TempDir::new().unwrap();
+        let iwads_dir = doom_home.child("iwads");
+        let wads_dir = doom_home.child("wads");
+        let source_ports_dir = doom_home.child("source-ports");
         set_var("TDL_DOOM_HOME_PATH", doom_home.path().to_str().unwrap());
-        let sut = UserSettings::set_from_doom_home().unwrap();
-        assert_eq!(
-            sut.iwads_path.as_path().to_str().unwrap(),
-            format!("{}/iwads", doom_home.path().display())
-        );
-        assert_eq!(
-            sut.wads_path.as_path().to_str().unwrap(),
-            format!("{}/wads", doom_home.path().display())
-        );
-        assert_eq!(
-            sut.source_ports_path.as_path().to_str().unwrap(),
-            format!("{}/source-ports", doom_home.path().display())
-        );
+        let _ = UserSettings::set_from_doom_home().unwrap();
+        iwads_dir.assert(predicate::path::is_dir());
+        wads_dir.assert(predicate::path::is_dir());
+        source_ports_dir.assert(predicate::path::is_dir());
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -15,15 +15,15 @@ impl UserSettings {
     pub fn set_from_doom_home() -> Result<UserSettings, Report> {
         let path_var = std::env::var("TDL_DOOM_HOME_PATH")?;
         let doom_home_path = Path::new(&path_var);
-        let iwad_pb = PathBuf::from(doom_home_path.join("iwads"));
+        let iwad_pb = doom_home_path.join("iwads");
         if !iwad_pb.exists() {
             std::fs::create_dir_all(iwad_pb.as_path())?;
         }
-        let wad_pb = PathBuf::from(doom_home_path.join("wads"));
+        let wad_pb = doom_home_path.join("wads");
         if !wad_pb.exists() {
             std::fs::create_dir_all(wad_pb.as_path())?;
         }
-        let sp_pb = PathBuf::from(doom_home_path.join("source-ports"));
+        let sp_pb = doom_home_path.join("source-ports");
         if !sp_pb.exists() {
             std::fs::create_dir_all(sp_pb.as_path())?;
         }
@@ -98,7 +98,7 @@ pub fn get_app_settings_dir_path() -> Result<PathBuf, Report> {
     let mut home_path = dirs::home_dir().unwrap();
     home_path.push(".config");
     home_path.push("tdl");
-    let result = std::env::var("TDL_SETTINGS_PATH").map(|x| PathBuf::from(x));
+    let result = std::env::var("TDL_SETTINGS_PATH").map(PathBuf::from);
     let pb = result.unwrap_or(home_path);
     ensure!(
         !pb.is_file(),

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -51,7 +51,7 @@ impl ObjectRepository {
     ///
     /// Should only be related to IO or if the object being retrieved is not valid JSON (which
     /// shouldn't happen if it's been saved by this application).
-    pub fn get<T: DeserializeOwned>(&self, id: &String) -> Result<T, Report> {
+    pub fn get<T: DeserializeOwned>(&self, id: &str) -> Result<T, Report> {
         let mut pb = PathBuf::from(&self.object_path);
         pb.push(format!("{}.json", id));
         debug!("Deserializing {}", pb.as_path().display());
@@ -70,7 +70,7 @@ impl ObjectRepository {
     /// Result will be an error if there is already an object with the specified ID.
     ///
     /// Any other errors would be from file IO or the JSON library.
-    pub fn save<T: Serialize>(&self, id: &String, object: &T) -> Result<(), Report> {
+    pub fn save<T: Serialize>(&self, id: &str, object: &T) -> Result<(), Report> {
         ensure!(!id.is_empty(), "To save the object, its ID must be set.");
         let serialized = serde_json::to_string(&object)?;
         let mut save_pb = PathBuf::from(&self.object_path);


### PR DESCRIPTION
## chore: Fix Clippy Errors/Warnings
    
This was the first time I had ran clippy, so there were quite a few things to fix here. It's now part of the CI process.

## ci: Initial CI Setup
    
The initial CI setup to get something going.
    
At this point, it simply just runs rustfmt, clippy and runs the unit tests. It explicitly runs `cargo test --bin tdl` because a `cargo test` command will attempt to also run the integration tests. We will only be able to run integration tests selectively, since some of them involve working with IWADs. Those will be restricted to running on local machines that have legally obtained copies of the IWADs.
    
There was one test changed that was using Unix style paths. These directories were checked instead by using assert_fs.