### PR TITLE
feat: profile ls command

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,3 +55,28 @@ jobs:
           key: ${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
       - name: run unit tests
         run: cargo test --bin tdl
+  integration-tests:
+    name: run integration tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: install rust
+        id: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: cargo caching
+        uses: actions/cache@v2.1.4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+      - name: run profile ls tests
+        run: cargo test --test profile_ls

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,6 +1874,7 @@ dependencies = [
  "structopt",
  "tar",
  "tempfile",
+ "test_helpers",
 ]
 
 [[package]]
@@ -1919,6 +1920,10 @@ checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "test_helpers"
+version = "0.1.0"
 
 [[package]]
 name = "textwrap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,6 @@ skim = "~0.9.4"
 assert_fs = "~1.0"
 assert_cmd = "~2.0"
 predicates = "~2.0"
+
+[dev-dependencies.test_helpers]
+path = "./test_helpers"

--- a/src/source_port.rs
+++ b/src/source_port.rs
@@ -56,6 +56,20 @@ impl FromStr for SourcePortType {
     }
 }
 
+impl std::fmt::Display for SourcePortType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DoomRetro => write!(f, "DoomRetro"),
+            Self::Dsda => write!(f, "Dsda"),
+            Self::GzDoom => write!(f, "GzDoom"),
+            Self::Odamex => write!(f, "Odamex"),
+            Self::PrBoom => write!(f, "PrBoom"),
+            Self::PrBoomUmapInfo => write!(f, "PrBoomUmapInfo"),
+            Self::Woof => write!(f, "Woof"),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SourcePort {
     pub source_port_type: SourcePortType,

--- a/test_helpers/Cargo.toml
+++ b/test_helpers/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "test_helpers"
+version = "0.1.0"
+publish = false
+license = "MIT OR BSD-3-Clause"
+edition = "2018"

--- a/test_helpers/src/lib.rs
+++ b/test_helpers/src/lib.rs
@@ -1,0 +1,14 @@
+pub mod helpers {
+    #[cfg(target_family = "unix")]
+    const FAKE_SOURCE_PORT_BIN_NAME: &str = "fake_source_port";
+    #[cfg(target_family = "windows")]
+    const FAKE_SOURCE_PORT_BIN_NAME: &str = "fake_source_port.exe";
+
+    pub fn get_fake_source_port_path() -> String {
+        let mut fake_source_port_path = std::env::current_dir().unwrap();
+        fake_source_port_path.push("target");
+        fake_source_port_path.push("debug");
+        fake_source_port_path.push(FAKE_SOURCE_PORT_BIN_NAME);
+        String::from(fake_source_port_path.as_path().to_str().unwrap())
+    }
+}

--- a/tests/play.rs
+++ b/tests/play.rs
@@ -2,11 +2,7 @@ use assert_cmd::Command;
 use assert_fs::prelude::*;
 use predicates::prelude::*;
 use std::path::PathBuf;
-
-#[cfg(target_family = "unix")]
-const FAKE_SOURCE_PORT_BIN_NAME: &str = "fake_source_port";
-#[cfg(target_family = "windows")]
-const FAKE_SOURCE_PORT_BIN_NAME: &str = "fake_source_port.exe";
+use test_helpers::helpers::get_fake_source_port_path;
 
 #[test]
 fn play_should_run_the_game_with_the_default_profile() {
@@ -451,12 +447,4 @@ fn play_should_run_the_game_with_the_selected_iwad_and_doom_map() {
         )))
         .stdout(predicate::str::contains("Game called with -warp: 1 7"))
         .stdout(predicate::str::contains("Game called with -skill: 4"));
-}
-
-fn get_fake_source_port_path() -> String {
-    let mut fake_source_port_path = std::env::current_dir().unwrap();
-    fake_source_port_path.push("target");
-    fake_source_port_path.push("debug");
-    fake_source_port_path.push(FAKE_SOURCE_PORT_BIN_NAME);
-    String::from(fake_source_port_path.as_path().to_str().unwrap())
 }

--- a/tests/profile_ls.rs
+++ b/tests/profile_ls.rs
@@ -1,0 +1,106 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use test_helpers::helpers::get_fake_source_port_path;
+
+#[test]
+fn profile_ls_with_2_profiles_should_list_the_added_profiles() {
+    let settings_file = assert_fs::NamedTempFile::new("tdl.json").unwrap();
+    let fake_source_port_path = get_fake_source_port_path();
+    let doom_home_dir = assert_fs::TempDir::new().unwrap();
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("add")
+        .arg("PrBoom")
+        .arg(&fake_source_port_path)
+        .arg("2.6")
+        .env("TDL_SETTINGS_PATH", settings_file.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("add")
+        .arg("PrBoomUmapInfo")
+        .arg(&fake_source_port_path)
+        .arg("2.6um")
+        .env("TDL_SETTINGS_PATH", settings_file.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("profile")
+        .arg("add")
+        .arg("--name")
+        .arg("default")
+        .arg("--type")
+        .arg("PrBoom")
+        .arg("--version")
+        .arg("2.6")
+        .arg("--skill")
+        .arg("UltraViolence")
+        .arg("--fullscreen")
+        .arg("--music")
+        .env("TDL_SETTINGS_PATH", settings_file.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("profile")
+        .arg("add")
+        .arg("--name")
+        .arg("profile2")
+        .arg("--type")
+        .arg("PrBoomUmapInfo")
+        .arg("--version")
+        .arg("2.6um")
+        .arg("--skill")
+        .arg("UltraViolence")
+        .arg("--fullscreen")
+        .env("TDL_SETTINGS_PATH", settings_file.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("profile")
+        .arg("ls")
+        .env("RUST_LOG", "debug")
+        .env("TDL_SETTINGS_PATH", settings_file.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Listing 2 profiles"))
+        .stdout(predicate::str::contains("Name"))
+        .stdout(predicate::str::contains("Source Port"))
+        .stdout(predicate::str::contains("Version"))
+        .stdout(predicate::str::contains("Is Default?"))
+        .stdout(predicate::str::contains("default"))
+        .stdout(predicate::str::contains("PrBoom"))
+        .stdout(predicate::str::contains("2.6"))
+        .stdout(predicate::str::contains("profile2"))
+        .stdout(predicate::str::contains("PrBoomUmapInfo"))
+        .stdout(predicate::str::contains("2.6um"));
+}
+
+#[test]
+fn profile_ls_with_no_profiles_should_print_empty_message() {
+    let settings_file = assert_fs::NamedTempFile::new("tdl.json").unwrap();
+    let doom_home_dir = assert_fs::TempDir::new().unwrap();
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("profile")
+        .arg("ls")
+        .env("RUST_LOG", "debug")
+        .env("TDL_SETTINGS_PATH", settings_file.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("No profiles have been added yet."))
+        .stderr(predicate::str::contains(
+            "Run the `profile add` command to create a new profile.",
+        ));
+}


### PR DESCRIPTION
A simple command that just lists all the profiles that have been added. They are printed out using the `prettytable` crate.

A test helper library was created for common functions. This only has a single function at the moment but I have no doubt that it will expand over time.

There's now been an additional job added to the PR workflow to run integration tests on all 3 platforms. Right now it's only running these profile tests because those are not dependent on having the IWADs present.

Also fixed a couple of clippy warnings. I thought the CI would be picking these up and would have done so when the last PR was merged. Will need to investigate this.