### PR TITLE
feat: `source port install` command

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -82,3 +82,25 @@ jobs:
         run: |
           cargo test --test profile_ls
           cargo test --test source_port_ls --features=rate-limiting-tests
+  win-integration-tests:
+    name: run windows specific integration tests
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: install rust
+        id: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: cargo caching
+        uses: actions/cache@v2.1.4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+      - name: run integration tests
+        run: cargo test --test source_port_install

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
+name = "bzip2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +265,19 @@ dependencies = [
  "owo-colors",
  "tracing-core",
  "tracing-error",
+]
+
+[[package]]
+name = "console"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "terminal_size",
+ "winapi",
 ]
 
 [[package]]
@@ -648,6 +682,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,6 +969,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
+dependencies = [
+ "console",
+ "lazy_static",
+ "number_prefix",
+ "regex",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,6 +1197,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -1905,6 +1963,8 @@ dependencies = [
  "duct",
  "env_logger 0.9.0",
  "flate2",
+ "fs_extra",
+ "indicatif",
  "lazy_static",
  "log",
  "maplit",
@@ -1925,6 +1985,9 @@ dependencies = [
  "tempfile",
  "test_helpers",
  "thiserror",
+ "url",
+ "zip",
+ "zip-extensions",
 ]
 
 [[package]]
@@ -1972,10 +2035,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "test_helpers"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "color-eyre",
 ]
 
 [[package]]
@@ -2476,4 +2550,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "zip"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
+dependencies = [
+ "byteorder",
+ "bzip2",
+ "crc32fast",
+ "flate2",
+ "thiserror",
+ "time 0.1.43",
+]
+
+[[package]]
+name = "zip-extensions"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64c3c977bc3434ce2d4bcea8ad3c644672de0f2c402b72b9171ca80a8885d14"
+dependencies = [
+ "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ dirs = "~1.0"
 duct = "~0.13"
 env_logger = "~0.9"
 flate2 = "~1.0"
+fs_extra = "~1.2.0"
+indicatif = "~0.16"
 lazy_static = "~1.4"
 log = "~0.4"
 maplit = "~1.0"
@@ -36,6 +38,9 @@ strum_macros = "~0.21"
 tar = "~0.4"
 tempfile = "~3.2"
 thiserror = "~1.0"
+url = "2.2.2"
+zip = "~0.5"
+zip-extensions = "~0.6"
 
 [features]
 default = ["reqwest/default-tls"]

--- a/resources/test_data/release_cache_entries/TorrSamaho.zandronum.latest.json
+++ b/resources/test_data/release_cache_entries/TorrSamaho.zandronum.latest.json
@@ -1,0 +1,11 @@
+{
+  "cached_date": "__CACHED_DATE__",
+  "release": {
+    "source_port": "Zandronum",
+    "owner": "TorrSamaho",
+    "repository": "zandronum",
+    "version": "no_latest_release",
+    "assets": []
+  }
+}
+

--- a/resources/test_data/release_cache_entries/bradharding.doomretro.latest.json
+++ b/resources/test_data/release_cache_entries/bradharding.doomretro.latest.json
@@ -1,0 +1,16 @@
+{
+  "cached_date": "__CACHED_DATE__",
+  "release": {
+    "source_port": "DoomRetro",
+    "owner": "bradharding",
+    "repository": "doomretro",
+    "version": "4.3",
+    "assets": [
+      [
+        "windows",
+        "https://github.com/bradharding/doomretro/releases/download/v4.3/doomretro-4.3-win64.zip"
+      ]
+    ]
+  }
+}
+

--- a/resources/test_data/release_cache_entries/chocolate-doom.chocolate-doom.latest.json
+++ b/resources/test_data/release_cache_entries/chocolate-doom.chocolate-doom.latest.json
@@ -1,0 +1,20 @@
+{
+  "cached_date": "__CACHED_DATE__",
+  "release": {
+    "source_port": "Chocolate",
+    "owner": "chocolate-doom",
+    "repository": "chocolate-doom",
+    "version": "3.0.0",
+    "assets": [
+      [
+        "windows",
+        "https://github.com/chocolate-doom/chocolate-doom/releases/download/chocolate-doom-3.0.0/chocolate-doom-3.0.0-win32.zip"
+      ],
+      [
+        "macos",
+        "https://github.com/chocolate-doom/chocolate-doom/releases/download/chocolate-doom-3.0.0/chocolate-doom-3.0.0.dmg"
+      ]
+    ]
+  }
+}
+

--- a/resources/test_data/release_cache_entries/coelckers.gzdoom.latest.json
+++ b/resources/test_data/release_cache_entries/coelckers.gzdoom.latest.json
@@ -1,0 +1,20 @@
+{
+  "cached_date": "__CACHED_DATE__",
+  "release": {
+    "source_port": "GzDoom",
+    "owner": "coelckers",
+    "repository": "gzdoom",
+    "version": "4.7.1",
+    "assets": [
+      [
+        "windows",
+        "https://github.com/coelckers/gzdoom/releases/download/g4.7.1/gzdoom-4-7-1-Windows-64bit.zip"
+      ],
+      [
+        "macos",
+        "https://github.com/coelckers/gzdoom/releases/download/g4.7.1/gzdoom-4-7-1-macOS.zip"
+      ]
+    ]
+  }
+}
+

--- a/resources/test_data/release_cache_entries/coelckers.prboom-plus.latest.json
+++ b/resources/test_data/release_cache_entries/coelckers.prboom-plus.latest.json
@@ -1,0 +1,16 @@
+{
+  "cached_date": "__CACHED_DATE__",
+  "release": {
+    "source_port": "PrBoomPlus",
+    "owner": "coelckers",
+    "repository": "prboom-plus",
+    "version": "2.6.1um",
+    "assets": [
+      [
+        "windows",
+        "https://github.com/coelckers/prboom-plus/releases/download/v2.6.1um/prboom-plus-261um-w32.zip"
+      ]
+    ]
+  }
+}
+

--- a/resources/test_data/release_cache_entries/drfrag666.gzdoom.latest.json
+++ b/resources/test_data/release_cache_entries/drfrag666.gzdoom.latest.json
@@ -1,0 +1,20 @@
+{
+  "cached_date": "__CACHED_DATE__",
+  "release": {
+    "source_port": "LzDoom",
+    "owner": "drfrag666",
+    "repository": "gzdoom",
+    "version": "3.88a",
+    "assets": [
+      [
+        "windows",
+        "https://github.com/drfrag666/gzdoom/releases/download/3.88a/LZDoom_3.88a_x64.zip"
+      ],
+      [
+        "macos",
+        "https://github.com/drfrag666/gzdoom/releases/download/3.88a/LZDoom_3.88a_macOS.zip"
+      ]
+    ]
+  }
+}
+

--- a/resources/test_data/release_cache_entries/drfrag666.rude.latest.json
+++ b/resources/test_data/release_cache_entries/drfrag666.rude.latest.json
@@ -1,0 +1,11 @@
+{
+  "cached_date": "__CACHED_DATE__",
+  "release": {
+    "source_port": "Rude",
+    "owner": "drfrag666",
+    "repository": "RUDE",
+    "version": "no_latest_release",
+    "assets": []
+  }
+}
+

--- a/resources/test_data/release_cache_entries/fabiangreffrath.crispy-doom.latest.json
+++ b/resources/test_data/release_cache_entries/fabiangreffrath.crispy-doom.latest.json
@@ -1,0 +1,16 @@
+{
+  "cached_date": "__CACHED_DATE__",
+  "release": {
+    "source_port": "Crispy",
+    "owner": "fabiangreffrath",
+    "repository": "crispy-doom",
+    "version": "5.10.3",
+    "assets": [
+      [
+        "windows",
+        "https://github.com/fabiangreffrath/crispy-doom/releases/download/crispy-doom-5.10.3/crispy-doom-5.10.3-win32.zip"
+      ]
+    ]
+  }
+}
+

--- a/resources/test_data/release_cache_entries/fabiangreffrath.woof.latest.json
+++ b/resources/test_data/release_cache_entries/fabiangreffrath.woof.latest.json
@@ -1,0 +1,16 @@
+{
+  "cached_date": "__CACHED_DATE__",
+  "release": {
+    "source_port": "Woof",
+    "owner": "fabiangreffrath",
+    "repository": "woof",
+    "version": "7.0.0",
+    "assets": [
+      [
+        "windows",
+        "https://github.com/fabiangreffrath/woof/releases/download/woof_7.0.0/Woof-7.0.0-win32.zip"
+      ]
+    ]
+  }
+}
+

--- a/resources/test_data/release_cache_entries/kraflab.dsda-doom.latest.json
+++ b/resources/test_data/release_cache_entries/kraflab.dsda-doom.latest.json
@@ -1,0 +1,11 @@
+{
+  "cached_date": "__CACHED_DATE__",
+  "release": {
+    "source_port": "Dsda",
+    "owner": "kraflab",
+    "repository": "dsda-doom",
+    "version": "0.21.3",
+    "assets": []
+  }
+}
+

--- a/resources/test_data/release_cache_entries/odamex.odamex.latest.json
+++ b/resources/test_data/release_cache_entries/odamex.odamex.latest.json
@@ -1,0 +1,20 @@
+{
+  "cached_date": "__CACHED_DATE__",
+  "release": {
+    "source_port": "Odamex",
+    "owner": "odamex",
+    "repository": "odamex",
+    "version": "0.9.5",
+    "assets": [
+      [
+        "windows",
+        "https://github.com/odamex/odamex/releases/download/0.9.5/odamex-win64-0.9.5.zip"
+      ],
+      [
+        "macos",
+        "https://github.com/odamex/odamex/releases/download/0.9.5/odamex-macos-0.9.5.dmg"
+      ]
+    ]
+  }
+}
+

--- a/resources/test_data/release_cache_entries/team-eternity.eternity.latest.json
+++ b/resources/test_data/release_cache_entries/team-eternity.eternity.latest.json
@@ -1,0 +1,20 @@
+{
+  "cached_date": "__CACHED_DATE__",
+  "release": {
+    "source_port": "EternityEngine",
+    "owner": "team-eternity",
+    "repository": "eternity",
+    "version": "4.02.00",
+    "assets": [
+      [
+        "windows",
+        "https://github.com/team-eternity/eternity/releases/download/4.02.00/ee-4.02.00-win64.zip"
+      ],
+      [
+        "macos",
+        "https://github.com/team-eternity/eternity/releases/download/4.02.00/ee-4.02.00-macos.dmg"
+      ]
+    ]
+  }
+}
+

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -100,10 +100,10 @@ impl ObjectRepository {
         let mut save_pb = PathBuf::from(&self.object_path);
         save_pb.push(format!("{}.json", id));
         if save_pb.exists() {
-            return Err(StorageError::ObjectIdError(String::from(format!(
+            return Err(StorageError::ObjectIdError(format!(
                 "The ID '{}' is already taken.",
                 id
-            ))));
+            )));
         }
         info!("Saving entry for {}", id);
         std::fs::write(save_pb.as_path(), serialized)?;

--- a/test_helpers/Cargo.toml
+++ b/test_helpers/Cargo.toml
@@ -6,4 +6,5 @@ license = "MIT OR BSD-3-Clause"
 edition = "2018"
 
 [dependencies]
+color-eyre =  "~0.5"
 chrono = { version = "~0.4", features = ["serde"] }

--- a/test_helpers/src/lib.rs
+++ b/test_helpers/src/lib.rs
@@ -1,7 +1,4 @@
-use chrono::{DateTime, Utc};
-use std::cell::Cell;
-
-pub mod helpers {
+pub mod source_port {
     #[cfg(target_family = "unix")]
     const FAKE_SOURCE_PORT_BIN_NAME: &str = "fake_source_port";
     #[cfg(target_family = "windows")]
@@ -16,22 +13,48 @@ pub mod helpers {
     }
 }
 
-thread_local! {
-    static CURRENT_DATE_TIME: Cell<DateTime<Utc>> = Cell::new(Utc::now());
-}
+pub mod date_time {
+    use chrono::{DateTime, Utc};
+    use std::cell::Cell;
 
-pub struct FakeUtc {}
-impl FakeUtc {
-    pub fn set_date_time(to: DateTime<Utc>) -> Result<(), String> {
-        CURRENT_DATE_TIME.with(|d| {
-            d.set(to);
-        });
-        Ok(())
+    thread_local! {
+        static CURRENT_DATE_TIME: Cell<DateTime<Utc>> = Cell::new(Utc::now());
     }
 
-    pub fn now() -> DateTime<Utc> {
-        CURRENT_DATE_TIME.with(|d| {
-            return d.get();
-        })
+    pub struct FakeUtc {}
+    impl FakeUtc {
+        pub fn set_date_time(to: DateTime<Utc>) -> Result<(), String> {
+            CURRENT_DATE_TIME.with(|d| {
+                d.set(to);
+            });
+            Ok(())
+        }
+
+        pub fn now() -> DateTime<Utc> {
+            CURRENT_DATE_TIME.with(|d| {
+                return d.get();
+            })
+        }
+    }
+}
+
+pub mod cache {
+    use chrono::{DateTime, Utc};
+    use color_eyre::{Report, Result};
+    use std::path::Path;
+
+    pub fn set_date_for_cache_entries<P: AsRef<Path>>(
+        cache_directory_path: P,
+        date: DateTime<Utc>,
+    ) -> Result<(), Report> {
+        let entries = std::fs::read_dir(cache_directory_path)?
+            .map(|x| x.map(|y| y.path()))
+            .collect::<Result<Vec<_>, std::io::Error>>()?;
+        for path in entries {
+            let cache_entry = std::fs::read_to_string(&path)?;
+            let cache_entry = cache_entry.replace("__CACHED_DATE__", &date.to_string());
+            std::fs::write(&path, cache_entry)?;
+        }
+        Ok(())
     }
 }

--- a/tests/play.rs
+++ b/tests/play.rs
@@ -2,7 +2,7 @@ use assert_cmd::Command;
 use assert_fs::prelude::*;
 use predicates::prelude::*;
 use std::path::PathBuf;
-use test_helpers::helpers::get_fake_source_port_path;
+use test_helpers::source_port::get_fake_source_port_path;
 
 #[test]
 fn play_should_run_the_game_with_the_default_profile() {

--- a/tests/profile_ls.rs
+++ b/tests/profile_ls.rs
@@ -1,6 +1,6 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
-use test_helpers::helpers::get_fake_source_port_path;
+use test_helpers::source_port::get_fake_source_port_path;
 
 #[test]
 fn profile_ls_with_2_profiles_should_list_the_added_profiles() {

--- a/tests/source_port_install.rs
+++ b/tests/source_port_install.rs
@@ -1,0 +1,533 @@
+/// Runs the `source-port install` command for each supported source port.
+///
+/// To avoid hitting the Github API, these tests are going to copy the Github responses to the
+/// cache directory.
+#[cfg(target_family = "windows")]
+use {
+    assert_cmd::Command,
+    assert_fs::prelude::*,
+    chrono::{Duration, Utc},
+    predicates::prelude::*,
+    test_helpers::cache::set_date_for_cache_entries,
+};
+
+#[cfg(target_family = "windows")]
+const CHOCOLATE_LATEST_VERSION: &str = "3.0.0";
+#[cfg(target_family = "windows")]
+const CRISPY_LATEST_VERSION: &str = "5.10.3";
+#[cfg(target_family = "windows")]
+const DOOM_RETRO_LATEST_VERSION: &str = "4.3";
+#[cfg(target_family = "windows")]
+const ETERNITY_ENGINE_LATEST_VERSION: &str = "4.02.00";
+#[cfg(target_family = "windows")]
+const GZDOOM_LATEST_VERSION: &str = "4.7.1";
+#[cfg(target_family = "windows")]
+const LZDOOM_LATEST_VERSION: &str = "3.88a";
+#[cfg(target_family = "windows")]
+const ODAMEX_LATEST_VERSION: &str = "0.9.5";
+#[cfg(target_family = "windows")]
+const PRBOOM_LATEST_VERSION: &str = "2.6.1um";
+#[cfg(target_family = "windows")]
+const WOOF_LATEST_VERSION: &str = "7.0.0";
+
+#[cfg(target_family = "windows")]
+#[test]
+fn source_port_install_should_install_the_latest_version_of_chocolate_doom() {
+    let cache_dt = Utc::now() - Duration::hours(1);
+
+    let settings_dir = assert_fs::TempDir::new().unwrap();
+    let release_cache_dir = settings_dir.child("release_cache");
+    release_cache_dir.create_dir_all().unwrap();
+    release_cache_dir
+        .copy_from("resources/test_data/release_cache_entries", &["*.json"])
+        .unwrap();
+    set_date_for_cache_entries(release_cache_dir.path(), cache_dt).unwrap();
+
+    let doom_home_dir = assert_fs::TempDir::new().unwrap();
+    let install_dir = doom_home_dir.child(format!(
+        "source-ports/chocolate-{}",
+        CHOCOLATE_LATEST_VERSION
+    ));
+    let sp_exe_file = install_dir.child("chocolate-doom.exe");
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("install")
+        .arg("Chocolate")
+        .env("TDL_SETTINGS_PATH", settings_dir.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    install_dir.assert(predicates::path::is_dir());
+    sp_exe_file.assert(predicates::path::is_file());
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("ls")
+        .env("TDL_SETTINGS_PATH", settings_dir.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::is_match(format!("Chocolate Doom.*{}.*Yes", CHOCOLATE_LATEST_VERSION))
+                .unwrap(),
+        );
+}
+
+#[cfg(target_family = "windows")]
+#[test]
+fn source_port_install_should_install_the_latest_version_of_crispy_doom() {
+    let cache_dt = Utc::now() - Duration::hours(1);
+
+    let settings_dir = assert_fs::TempDir::new().unwrap();
+    let release_cache_dir = settings_dir.child("release_cache");
+    release_cache_dir.create_dir_all().unwrap();
+    release_cache_dir
+        .copy_from("resources/test_data/release_cache_entries", &["*.json"])
+        .unwrap();
+    set_date_for_cache_entries(release_cache_dir.path(), cache_dt).unwrap();
+
+    let doom_home_dir = assert_fs::TempDir::new().unwrap();
+    let install_dir = doom_home_dir.child(format!("source-ports/crispy-{}", CRISPY_LATEST_VERSION));
+    let sp_exe_file = install_dir.child("crispy-doom.exe");
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("install")
+        .arg("Crispy")
+        .env("TDL_SETTINGS_PATH", settings_dir.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    install_dir.assert(predicates::path::is_dir());
+    sp_exe_file.assert(predicates::path::is_file());
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("ls")
+        .env("TDL_SETTINGS_PATH", settings_dir.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::is_match(format!("Crispy Doom.*{}.*Yes", CRISPY_LATEST_VERSION))
+                .unwrap(),
+        );
+}
+
+#[cfg(target_family = "windows")]
+#[test]
+fn source_port_install_should_install_the_latest_version_of_doom_retro() {
+    let cache_dt = Utc::now() - Duration::hours(1);
+
+    let settings_dir = assert_fs::TempDir::new().unwrap();
+    let release_cache_dir = settings_dir.child("release_cache");
+    release_cache_dir.create_dir_all().unwrap();
+    release_cache_dir
+        .copy_from("resources/test_data/release_cache_entries", &["*.json"])
+        .unwrap();
+    set_date_for_cache_entries(release_cache_dir.path(), cache_dt).unwrap();
+
+    let doom_home_dir = assert_fs::TempDir::new().unwrap();
+    let install_dir = doom_home_dir.child(format!(
+        "source-ports/doomretro-{}",
+        DOOM_RETRO_LATEST_VERSION
+    ));
+    let sp_exe_file = install_dir.child("doomretro.exe");
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("install")
+        .arg("DoomRetro")
+        .env("TDL_SETTINGS_PATH", settings_dir.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    install_dir.assert(predicates::path::is_dir());
+    sp_exe_file.assert(predicates::path::is_file());
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("ls")
+        .env("TDL_SETTINGS_PATH", settings_dir.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::is_match(format!("Doom Retro.*{}.*Yes", DOOM_RETRO_LATEST_VERSION))
+                .unwrap(),
+        );
+}
+
+#[cfg(target_family = "windows")]
+#[test]
+fn source_port_install_should_fail_to_install_the_latest_version_of_dsda() {
+    let cache_dt = Utc::now() - Duration::hours(1);
+
+    let settings_dir = assert_fs::TempDir::new().unwrap();
+    let release_cache_dir = settings_dir.child("release_cache");
+    release_cache_dir.create_dir_all().unwrap();
+    release_cache_dir
+        .copy_from("resources/test_data/release_cache_entries", &["*.json"])
+        .unwrap();
+    set_date_for_cache_entries(release_cache_dir.path(), cache_dt).unwrap();
+
+    let doom_home_dir = assert_fs::TempDir::new().unwrap();
+    let install_dir =
+        doom_home_dir.child(format!("source-ports/dsda-{}", DOOM_RETRO_LATEST_VERSION));
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("install")
+        .arg("Dsda")
+        .env("TDL_SETTINGS_PATH", settings_dir.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Failed to install the latest version of DSDA Doom",
+        ))
+        .stderr(predicate::str::contains(
+            "You can try the command again with the --version argument to install a specific version",
+        ))
+        .stderr(predicate::str::contains(
+            "Check the Github repository for DSDA Doom to see what versions are available",
+        ));
+
+    install_dir.assert(predicates::path::missing());
+}
+
+#[cfg(target_family = "windows")]
+#[test]
+fn source_port_install_should_install_the_latest_version_of_eternity_engine() {
+    let cache_dt = Utc::now() - Duration::hours(1);
+
+    let settings_dir = assert_fs::TempDir::new().unwrap();
+    let release_cache_dir = settings_dir.child("release_cache");
+    release_cache_dir.create_dir_all().unwrap();
+    release_cache_dir
+        .copy_from("resources/test_data/release_cache_entries", &["*.json"])
+        .unwrap();
+    set_date_for_cache_entries(release_cache_dir.path(), cache_dt).unwrap();
+
+    let doom_home_dir = assert_fs::TempDir::new().unwrap();
+    let install_dir = doom_home_dir.child(format!(
+        "source-ports/eternityengine-{}",
+        ETERNITY_ENGINE_LATEST_VERSION
+    ));
+    let sp_exe_file = install_dir.child("eternity.exe");
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("install")
+        .arg("EternityEngine")
+        .env("TDL_SETTINGS_PATH", settings_dir.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    install_dir.assert(predicates::path::is_dir());
+    sp_exe_file.assert(predicates::path::is_file());
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("ls")
+        .env("TDL_SETTINGS_PATH", settings_dir.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::is_match(format!(
+                "Eternity Engine.*{}.*Yes",
+                ETERNITY_ENGINE_LATEST_VERSION
+            ))
+            .unwrap(),
+        );
+}
+
+#[cfg(target_family = "windows")]
+#[test]
+fn source_port_install_should_install_the_latest_version_of_gzdoom() {
+    let cache_dt = Utc::now() - Duration::hours(1);
+
+    let settings_dir = assert_fs::TempDir::new().unwrap();
+    let release_cache_dir = settings_dir.child("release_cache");
+    release_cache_dir.create_dir_all().unwrap();
+    release_cache_dir
+        .copy_from("resources/test_data/release_cache_entries", &["*.json"])
+        .unwrap();
+    set_date_for_cache_entries(release_cache_dir.path(), cache_dt).unwrap();
+
+    let doom_home_dir = assert_fs::TempDir::new().unwrap();
+    let install_dir = doom_home_dir.child(format!("source-ports/gzdoom-{}", GZDOOM_LATEST_VERSION));
+    let sp_exe_file = install_dir.child("gzdoom.exe");
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("install")
+        .arg("GzDoom")
+        .env("TDL_SETTINGS_PATH", settings_dir.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    install_dir.assert(predicates::path::is_dir());
+    sp_exe_file.assert(predicates::path::is_file());
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("ls")
+        .env("TDL_SETTINGS_PATH", settings_dir.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::is_match(format!("GZDoom.*{}.*Yes", GZDOOM_LATEST_VERSION)).unwrap(),
+        );
+}
+
+#[cfg(target_family = "windows")]
+#[test]
+fn source_port_install_should_install_the_latest_version_of_lzdoom() {
+    let cache_dt = Utc::now() - Duration::hours(1);
+
+    let settings_dir = assert_fs::TempDir::new().unwrap();
+    let release_cache_dir = settings_dir.child("release_cache");
+    release_cache_dir.create_dir_all().unwrap();
+    release_cache_dir
+        .copy_from("resources/test_data/release_cache_entries", &["*.json"])
+        .unwrap();
+    set_date_for_cache_entries(release_cache_dir.path(), cache_dt).unwrap();
+
+    let doom_home_dir = assert_fs::TempDir::new().unwrap();
+    let install_dir = doom_home_dir.child(format!("source-ports/lzdoom-{}", LZDOOM_LATEST_VERSION));
+    let sp_exe_file = install_dir.child("lzdoom.exe");
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("install")
+        .arg("LzDoom")
+        .env("TDL_SETTINGS_PATH", settings_dir.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    install_dir.assert(predicates::path::is_dir());
+    sp_exe_file.assert(predicates::path::is_file());
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("ls")
+        .env("TDL_SETTINGS_PATH", settings_dir.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::is_match(format!("LZDoom.*{}.*Yes", LZDOOM_LATEST_VERSION)).unwrap(),
+        );
+}
+
+#[cfg(target_family = "windows")]
+#[test]
+fn source_port_install_should_install_the_latest_version_of_odamex() {
+    let cache_dt = Utc::now() - Duration::hours(1);
+
+    let settings_dir = assert_fs::TempDir::new().unwrap();
+    let release_cache_dir = settings_dir.child("release_cache");
+    release_cache_dir.create_dir_all().unwrap();
+    release_cache_dir
+        .copy_from("resources/test_data/release_cache_entries", &["*.json"])
+        .unwrap();
+    set_date_for_cache_entries(release_cache_dir.path(), cache_dt).unwrap();
+
+    let doom_home_dir = assert_fs::TempDir::new().unwrap();
+    let install_dir = doom_home_dir.child(format!("source-ports/odamex-{}", ODAMEX_LATEST_VERSION));
+    let sp_exe_file = install_dir.child("odamex.exe");
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("install")
+        .arg("Odamex")
+        .env("TDL_SETTINGS_PATH", settings_dir.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    install_dir.assert(predicates::path::is_dir());
+    sp_exe_file.assert(predicates::path::is_file());
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("ls")
+        .env("TDL_SETTINGS_PATH", settings_dir.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::is_match(format!("Odamex.*{}.*Yes", ODAMEX_LATEST_VERSION)).unwrap(),
+        );
+}
+
+#[cfg(target_family = "windows")]
+#[test]
+fn source_port_install_should_install_the_latest_version_of_prboom() {
+    let cache_dt = Utc::now() - Duration::hours(1);
+
+    let settings_dir = assert_fs::TempDir::new().unwrap();
+    let release_cache_dir = settings_dir.child("release_cache");
+    release_cache_dir.create_dir_all().unwrap();
+    release_cache_dir
+        .copy_from("resources/test_data/release_cache_entries", &["*.json"])
+        .unwrap();
+    set_date_for_cache_entries(release_cache_dir.path(), cache_dt).unwrap();
+
+    let doom_home_dir = assert_fs::TempDir::new().unwrap();
+    let install_dir = doom_home_dir.child(format!("source-ports/prboom-{}", PRBOOM_LATEST_VERSION));
+    let sp_exe_file = install_dir.child("prboom-plus.exe");
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("install")
+        .arg("PrBoomPlus")
+        .env("TDL_SETTINGS_PATH", settings_dir.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    install_dir.assert(predicates::path::is_dir());
+    sp_exe_file.assert(predicates::path::is_file());
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("ls")
+        .env("TDL_SETTINGS_PATH", settings_dir.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::is_match(format!("PrBoom Plus.*{}.*Yes", PRBOOM_LATEST_VERSION))
+                .unwrap(),
+        );
+}
+
+#[cfg(target_family = "windows")]
+#[test]
+fn source_port_install_should_install_the_latest_version_of_woof() {
+    let cache_dt = Utc::now() - Duration::hours(1);
+
+    let settings_dir = assert_fs::TempDir::new().unwrap();
+    let release_cache_dir = settings_dir.child("release_cache");
+    release_cache_dir.create_dir_all().unwrap();
+    release_cache_dir
+        .copy_from("resources/test_data/release_cache_entries", &["*.json"])
+        .unwrap();
+    set_date_for_cache_entries(release_cache_dir.path(), cache_dt).unwrap();
+
+    let doom_home_dir = assert_fs::TempDir::new().unwrap();
+    let install_dir = doom_home_dir.child(format!("source-ports/woof-{}", WOOF_LATEST_VERSION));
+    let archive_dir = install_dir.child(format!("Woof-{}-win32", WOOF_LATEST_VERSION));
+    let sp_exe_file = install_dir.child("woof.exe");
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("install")
+        .arg("Woof")
+        .env("TDL_SETTINGS_PATH", settings_dir.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    install_dir.assert(predicates::path::is_dir());
+    sp_exe_file.assert(predicates::path::is_file());
+    // The archive for Woof contains a directory at its root level. The files should be moved to
+    // the parent directory and the directory from the archive should be deleted.
+    archive_dir.assert(predicates::path::missing());
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("ls")
+        .env("TDL_SETTINGS_PATH", settings_dir.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match(format!("Woof!.*{}.*Yes", WOOF_LATEST_VERSION)).unwrap());
+}
+
+#[cfg(target_family = "windows")]
+#[test]
+fn source_port_install_should_fail_if_destination_dir_already_exists() {
+    let cache_dt = Utc::now() - Duration::hours(1);
+
+    let settings_dir = assert_fs::TempDir::new().unwrap();
+    let release_cache_dir = settings_dir.child("release_cache");
+    release_cache_dir.create_dir_all().unwrap();
+    release_cache_dir
+        .copy_from("resources/test_data/release_cache_entries", &["*.json"])
+        .unwrap();
+    set_date_for_cache_entries(release_cache_dir.path(), cache_dt).unwrap();
+
+    let doom_home_dir = assert_fs::TempDir::new().unwrap().into_persistent();
+    let install_dir = doom_home_dir.child(format!(
+        "source-ports/chocolate-{}",
+        CHOCOLATE_LATEST_VERSION
+    ));
+    install_dir.create_dir_all().unwrap();
+    let sp_exe_file = install_dir.child("chocolate-doom.exe");
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("install")
+        .arg("Chocolate")
+        .env("TDL_SETTINGS_PATH", settings_dir.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Failed to install the latest version of Chocolate Doom",
+        ))
+        .stderr(predicate::str::contains(format!(
+            "Remove the {} directory and run the command again",
+            install_dir.path().display()
+        )));
+    sp_exe_file.assert(predicates::path::missing());
+}
+
+#[cfg(target_family = "windows")]
+#[test]
+fn source_port_install_should_fail_if_the_source_port_is_already_installed() {
+    let cache_dt = Utc::now() - Duration::hours(1);
+
+    let settings_dir = assert_fs::TempDir::new().unwrap();
+    let release_cache_dir = settings_dir.child("release_cache");
+    release_cache_dir.create_dir_all().unwrap();
+    release_cache_dir
+        .copy_from("resources/test_data/release_cache_entries", &["*.json"])
+        .unwrap();
+    set_date_for_cache_entries(release_cache_dir.path(), cache_dt).unwrap();
+
+    let doom_home_dir = assert_fs::TempDir::new().unwrap();
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("install")
+        .arg("PrBoomPlus")
+        .env("TDL_SETTINGS_PATH", settings_dir.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("tdl").unwrap();
+    cmd.arg("source-port")
+        .arg("install")
+        .arg("PrBoomPlus")
+        .env("TDL_SETTINGS_PATH", settings_dir.path().to_str().unwrap())
+        .env("TDL_DOOM_HOME_PATH", doom_home_dir.path().to_str().unwrap())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(format!(
+            "Version {} of PrBoom Plus is already installed",
+            PRBOOM_LATEST_VERSION
+        )));
+}

--- a/tests/source_port_install.rs
+++ b/tests/source_port_install.rs
@@ -471,7 +471,7 @@ fn source_port_install_should_fail_if_destination_dir_already_exists() {
 
     let doom_home_dir = assert_fs::TempDir::new().unwrap().into_persistent();
     let install_dir = doom_home_dir.child(format!(
-        "source-ports/chocolate-{}",
+        "source-ports\\chocolate-{}",
         CHOCOLATE_LATEST_VERSION
     ));
     install_dir.create_dir_all().unwrap();

--- a/tests/source_port_ls.rs
+++ b/tests/source_port_ls.rs
@@ -16,7 +16,7 @@ const CRISPY_LATEST_VERSION: &str = "5.10.3";
 #[cfg(feature = "rate-limiting-tests")]
 const DOOM_RETRO_LATEST_VERSION: &str = "4.3";
 #[cfg(feature = "rate-limiting-tests")]
-const DSDA_DOOM_LATEST_VERSION: &str = "0.21.3";
+const DSDA_DOOM_LATEST_VERSION: &str = "0.22.1";
 #[cfg(feature = "rate-limiting-tests")]
 const ETERNITY_ENGINE_LATEST_VERSION: &str = "4.02.00";
 #[cfg(feature = "rate-limiting-tests")]
@@ -28,7 +28,7 @@ const ODAMEX_LATEST_VERSION: &str = "0.9.5";
 #[cfg(feature = "rate-limiting-tests")]
 const PRBOOM_LATEST_VERSION: &str = "2.6.1um";
 #[cfg(feature = "rate-limiting-tests")]
-const WOOF_LATEST_VERSION: &str = "7.0.0";
+const WOOF_LATEST_VERSION: &str = "8.1.0";
 
 #[cfg(feature = "rate-limiting-tests")]
 #[test]


### PR DESCRIPTION
## feat: `source-port install` command

Installs the latest version of the specified source port, by downloading the latest build from Github and extracting it to `TDL_DOOM_HOME\<source-port>-<version>`. Example: `source-port install Crispy`.

This command is only supported on Windows. I may extend it later to support macOS, but I don't think it makes sense for Linux, where people would generally be using package managers to install builds of Doom, or at least that's my understanding. Users on these operating systems would use the `source-port add` command after installing the source port by some other means.

Given this command works with and extracts zip/tar archives, it was more amenable to integration testing rather than unit testing. Unit testing would have necessitated lots of boilerplate that seemed overkill.

The integration test runs the command and checks for the existence of the extracted exe, then runs the `source-port ls` command to verify that TDL now considers it to be installed. This was actually good because the `source-port ls` command had to be extended to indicate whether the source port had been installed, so I ended up with more functionality.

It was important that these tests didn't hit the Github API, so the test sets up dummy cache entries that are returned when the command queries for the latest release. This test data shouldn't require any more maintenance than the other tests that are using Github responses.
## ci: run the source port install tests on windows

This runs in a separate job because we only want to run these tests on Windows, since the command isn't supported for Linux or macOS. There may well be other Windows-specific features, so we can add any additional test runs in this job.

## refactor: reorganise source port code

I wanted to put a bit more organisation around the source port management code, since the files for both the source port and command modules were becoming quite big.

The following changes were made:

* Split the code into public, private and test sections, using doc comments to try and delineate the sections in a fairly clear way.
* Refactor the source port command match statement to call functions for each subcommand, because it was becoming difficult to read with inline code for the subcommands.
* Refactor some subcommands to use smaller utility functions, again for readability and to try and make them a bit easier to understand.
* Remove the 'Error' suffix for each of the source port error types. I actually wanted this suffix to be applied, but clippy advised against it. A link to the linting rule is in the source.